### PR TITLE
fix(babel): plugins for optional chaining and nullish coalescing operator

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,4 @@
 module.exports = {
+  plugins: ['@babel/plugin-proposal-nullish-coalescing-operator', '@babel/plugin-proposal-optional-chaining'],
   presets: ['@vue/cli-plugin-babel/preset'],
 };


### PR DESCRIPTION
### Changes

- add `@babel/plugin-proposal-nullish-coalescing-operator`
- add `@babel/plugin-proposal-optional-chaining`

### Screenshots

### Code Coverage
